### PR TITLE
Automatically restart runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,15 @@ Colab notebooks created directly from Google Drive are tailored for Python progr
 
 ```swift
 !curl "https://raw.githubusercontent.com/philipturner/swift-colab/release/latest/install_swift.sh" --output "install_swift.sh"
-!bash "install_swift.sh" "5.6.2" #// Replace 5.6.2 with newest Swift version.
-#// After this cell finishes, go to Runtime > Restart runtime.
+!bash "install_swift.sh" "https://download.swift.org/swift-5.7-branch/ubuntu1804/swift-5.7-DEVELOPMENT-SNAPSHOT-2022-06-13-a/swift-5.7-DEVELOPMENT-SNAPSHOT-2022-06-13-a-ubuntu18.04.tar.gz" #// Replace 5.6.2 with newest Swift version.
+#// Restart runtime.
+import os
+os.kill(os.getpid(), 9)
+#// Expected warnings:
+#// "Unrecognized runtime 'swift'; defaulting to 'python3'".
+#// "Your session crashed. Automatically restarting".
+#// "Your session restarted after a crash. Diagnosing..."
+#// "Your session crashed for an unknown reason.""
 ```
 
 > Tip: Colab measures how long you keep a notebook open without interacting with it. If you exceed the time limit of Colab's free tier, it may restart in Python mode. That means Swift code executes as if it's Python code. In that situation, repeat the process outlined above to return to Swift mode.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Colab notebooks created directly from Google Drive are tailored for Python progr
 
 ```swift
 !curl "https://raw.githubusercontent.com/philipturner/swift-colab/release/latest/install_swift.sh" --output "install_swift.sh"
-!bash "install_swift.sh" "https://download.swift.org/swift-5.7-branch/ubuntu1804/swift-5.7-DEVELOPMENT-SNAPSHOT-2022-06-13-a/swift-5.7-DEVELOPMENT-SNAPSHOT-2022-06-13-a-ubuntu18.04.tar.gz" #// Replace 5.6.2 with newest Swift version.
+!bash "install_swift.sh" "5.6.2" #// Replace 5.6.2 with newest Swift version.
 #// Restart runtime.
 import os
 os.kill(os.getpid(), 9)


### PR DESCRIPTION
There's an easy way to restart the runtime without the arduous task of clicking the menu! [Found on StackOverflow](https://stackoverflow.com/a/53165687/336146).

```
import os
os.kill(os.getpid(), 9)
```

I also added some comments to explain the benign error messages that appear.

I'm not sure where to PR the Colab notebook itself.